### PR TITLE
String to ID

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2313,7 +2313,7 @@ isStream.transform = function (stream) {
 /***/ (function(__unusedmodule, exports) {
 
 CREATE_TAG_MUTATION = `
-  mutation($clientId: String!, $refName: String!, $commitOid: GitObjectID!, $repositoryId: String! ) {
+  mutation($clientId: String!, $refName: String!, $commitOid: GitObjectID!, $repositoryId: ID! ) {
     createRef( input:{ clientMutationId: $clientId, name: $refName, oid: $commitOid, repositoryId: $repositoryId } ) {
       clientMutationId
       ref {

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,5 +1,5 @@
 CREATE_TAG_MUTATION = `
-  mutation($clientId: String!, $refName: String!, $commitOid: GitObjectID!, $repositoryId: String! ) {
+  mutation($clientId: String!, $refName: String!, $commitOid: GitObjectID!, $repositoryId: ID! ) {
     createRef( input:{ clientMutationId: $clientId, name: $refName, oid: $commitOid, repositoryId: $repositoryId } ) {
       clientMutationId
       ref {


### PR DESCRIPTION
## Commit Message

`String!` when referring to GH IDs was changed to `ID!`. This PR fixes the references.